### PR TITLE
Added a Jenkinsfile to run CI easily

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,81 @@
+def amd_image
+def arm_image
+def intel_image
+def restoreMTime() {
+    sh '''
+        git restore-mtime
+        touch -t $(git show -s --date=format:'%Y%m%d%H%M.%S' --format=%cd HEAD) .git
+    '''
+}
+
+
+pipeline {
+    agent any
+    environment {
+        DOCKER_GIT_TAG="$AWS_ECR_URL/heimdall:${GIT_COMMIT.substring(0,8)}"
+        DOCKER_BUILDKIT=1
+    }
+    stages {
+        stage('build and push') {
+            parallel {
+                stage('Build and push amd64 image') {
+                    agent {
+                        label 'amd64_jenkins_agent'
+                    }
+                    steps {
+                        script {
+                            DOCKER_GIT_TAG_AMD="$DOCKER_GIT_TAG" + "_amd64"
+                            restoreMTime()
+                            try {
+                                amd_image = docker.build("$DOCKER_GIT_TAG_AMD")
+                            } catch (e) {
+                                def err = "amd64 build failed: ${e}"
+                                error(err)
+                            }
+                            amd_image.push()
+                            amd_image.push('latest_amd3')
+                        }
+                    }
+                }
+                stage('Build and push arm64 image') {
+                    agent {
+                        label 'arm64_jenkins_agent'
+                    }
+                    steps {
+                        script {
+                            DOCKER_GIT_TAG_ARM="$DOCKER_GIT_TAG" + "_arm64"
+                            restoreMTime()
+                            try {
+                                arm_image = docker.build("$DOCKER_GIT_TAG_ARM")
+                            } catch (e) {
+                                def err = "arm64 build failed: ${e}"
+                                error(err)
+                            }
+                            arm_image.push()
+                            arm_image.push('latest_graviton2')
+                        }
+                    }
+                }
+                stage('Build and push intel image') {
+                    agent {
+                        label 'intel_jenkins_agent'
+                    }
+                    steps {
+                        script {
+                            DOCKER_GIT_TAG_INTEL="$DOCKER_GIT_TAG" + "_intel_sky_lake"
+                            restoreMTime()
+                            try {
+                                intel_image = docker.build("$DOCKER_GIT_TAG_INTEL")
+                            } catch (e) {
+                                def err = "intel_sky_lake build failed: ${e}"
+                                error(err)
+                            }
+                            intel_image.push()
+                            intel_image.push('latest')
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
To facilitate CI, a new Jenkinsfile has been added with multiples stages:
 - build on 3 different proc/arch
   - AMD / ARM / INTEL

 - Push 6 different images:
    - $git_commit_arm64 / latest_graviton2
    - $git_commit_amd64 / latest_amd3
    - $git_commit_intel / latest